### PR TITLE
data-structure, algorithm: add interfaces

### DIFF
--- a/data-structure/priorityqueue/priorityqueue.go
+++ b/data-structure/priorityqueue/priorityqueue.go
@@ -9,23 +9,23 @@ type PriorityQueue[T any] struct {
 	h *hp[T]
 }
 
-func New[T any](compare func(a, b T) int) *PriorityQueue[T] {
+// 昇順
+func NewPriorityQueue[T cmp.Ordered]() *PriorityQueue[T] {
+	pq := NewPriorityQueueFunc(cmp.Compare[T])
+	return pq
+}
+
+func NewPriorityQueueFunc[T any](compare func(a, b T) int) *PriorityQueue[T] {
 	pq := new(PriorityQueue[T])
 	pq.h.s = make([]T, 0)
 	pq.h.compare = compare
 	return pq
 }
 
-// 昇順
-func NewOrdered[T cmp.Ordered]() *PriorityQueue[T] {
-	pq := New(cmp.Compare[T])
-	return pq
-}
-
+func (pq *PriorityQueue[T]) Len() int    { return pq.h.Len() }
+func (pq *PriorityQueue[T]) Top() T      { return pq.h.s[0] }
 func (pq *PriorityQueue[T]) Enqueue(x T) { heap.Push(pq.h, x) }
 func (pq *PriorityQueue[T]) Dequeue() T  { return heap.Pop(pq.h).(T) }
-func (pq *PriorityQueue[T]) Top() T      { return pq.h.s[0] }
-func (pq *PriorityQueue[T]) Len() int    { return pq.h.Len() }
 
 type hp[T any] struct {
 	s       []T

--- a/data-structure/priorityqueue/priorityqueue.go
+++ b/data-structure/priorityqueue/priorityqueue.go
@@ -5,42 +5,44 @@ import (
 	"container/heap"
 )
 
-type PriorityQueue[T any] struct {
-	h *hp[T]
+type PriorityQueue[T any] interface {
+	Len() int
+	Top() T
+	Enqueue(x T)
+	Dequeue() T
 }
 
 // 昇順
-func NewPriorityQueue[T cmp.Ordered]() *PriorityQueue[T] {
+func NewPriorityQueue[T cmp.Ordered]() PriorityQueue[T] {
 	pq := NewPriorityQueueFunc(cmp.Compare[T])
 	return pq
 }
 
-func NewPriorityQueueFunc[T any](compare func(a, b T) int) *PriorityQueue[T] {
-	pq := new(PriorityQueue[T])
-	pq.h.s = make([]T, 0)
-	pq.h.compare = compare
+func NewPriorityQueueFunc[T any](compare func(a, b T) int) PriorityQueue[T] {
+	pq := new(priorityQueue[T])
+	pq.s = make([]T, 0)
+	pq.compare = compare
 	return pq
 }
 
-func (pq *PriorityQueue[T]) Len() int    { return pq.h.Len() }
-func (pq *PriorityQueue[T]) Top() T      { return pq.h.s[0] }
-func (pq *PriorityQueue[T]) Enqueue(x T) { heap.Push(pq.h, x) }
-func (pq *PriorityQueue[T]) Dequeue() T  { return heap.Pop(pq.h).(T) }
-
-type hp[T any] struct {
+type priorityQueue[T any] struct {
 	s       []T
 	compare func(a, b T) int
 }
 
-func (h hp[T]) Len() int           { return len(h.s) }
-func (h hp[T]) Swap(i, j int)      { h.s[i], h.s[j] = h.s[j], h.s[i] }
-func (h hp[T]) Less(i, j int) bool { return h.compare(h.s[i], h.s[j]) < 0 }
-func (h *hp[T]) Push(x any) {
-	h.s = append(h.s, x.(T))
+func (pq *priorityQueue[T]) Top() T      { return pq.s[0] }
+func (pq *priorityQueue[T]) Enqueue(x T) { heap.Push(pq, x) }
+func (pq *priorityQueue[T]) Dequeue() T  { return heap.Pop(pq).(T) }
+
+func (pq priorityQueue[T]) Len() int           { return len(pq.s) }
+func (pq priorityQueue[T]) Swap(i, j int)      { pq.s[i], pq.s[j] = pq.s[j], pq.s[i] }
+func (pq priorityQueue[T]) Less(i, j int) bool { return pq.compare(pq.s[i], pq.s[j]) < 0 }
+func (pq *priorityQueue[T]) Push(x any) {
+	pq.s = append(pq.s, x.(T))
 }
-func (h *hp[T]) Pop() any {
-	n := len(h.s)
-	res := (h.s)[n-1]
-	h.s = (h.s)[:n-1]
+func (pq *priorityQueue[T]) Pop() any {
+	n := len(pq.s)
+	res := (pq.s)[n-1]
+	pq.s = (pq.s)[:n-1]
 	return res
 }

--- a/data-structure/priorityqueue/priorityqueue.go
+++ b/data-structure/priorityqueue/priorityqueue.go
@@ -14,20 +14,22 @@ type PriorityQueue[T any] interface {
 
 // 昇順
 func NewPriorityQueue[T cmp.Ordered]() PriorityQueue[T] {
-	pq := NewPriorityQueueFunc(cmp.Compare[T])
+	pq := NewPriorityQueueFunc(cmp.Less[T])
 	return pq
 }
 
-func NewPriorityQueueFunc[T any](compare func(a, b T) int) PriorityQueue[T] {
+// lessは並んでる時にtrue、並んでない時にfalseを返すような関数
+// 参考: https://pkg.go.dev/cmp@go1.22.0#Less
+func NewPriorityQueueFunc[T any](less func(a, b T) bool) PriorityQueue[T] {
 	pq := new(priorityQueue[T])
 	pq.s = make([]T, 0)
-	pq.compare = compare
+	pq.less = less
 	return pq
 }
 
 type priorityQueue[T any] struct {
-	s       []T
-	compare func(a, b T) int
+	s    []T
+	less func(a, b T) bool
 }
 
 func (pq *priorityQueue[T]) Top() T      { return pq.s[0] }
@@ -36,7 +38,7 @@ func (pq *priorityQueue[T]) Dequeue() T  { return heap.Pop(pq).(T) }
 
 func (pq priorityQueue[T]) Len() int           { return len(pq.s) }
 func (pq priorityQueue[T]) Swap(i, j int)      { pq.s[i], pq.s[j] = pq.s[j], pq.s[i] }
-func (pq priorityQueue[T]) Less(i, j int) bool { return pq.compare(pq.s[i], pq.s[j]) < 0 }
+func (pq priorityQueue[T]) Less(i, j int) bool { return pq.less(pq.s[i], pq.s[j]) }
 func (pq *priorityQueue[T]) Push(x any) {
 	pq.s = append(pq.s, x.(T))
 }

--- a/data-structure/priorityqueue/priorityqueue.go
+++ b/data-structure/priorityqueue/priorityqueue.go
@@ -18,7 +18,7 @@ func NewPriorityQueue[T cmp.Ordered]() PriorityQueue[T] {
 	return pq
 }
 
-// lessは並んでる時にtrue、並んでない時にfalseを返すような関数
+// cmp.Less関数を参考にlessを実装する
 // 参考: https://pkg.go.dev/cmp@go1.22.0#Less
 func NewPriorityQueueFunc[T any](less func(a, b T) bool) PriorityQueue[T] {
 	pq := new(priorityQueue[T])

--- a/data-structure/segtree/segtree.go
+++ b/data-structure/segtree/segtree.go
@@ -1,19 +1,15 @@
 package segtree
 
-// 参考にさせていただいた記事:
-// https://maspypy.com/segment-tree-%e3%81%ae%e3%81%8a%e5%8b%89%e5%bc%b71
-// https://github.com/ktateish/go-competitive/blob/master/ac_segtree.go2
-// https://github.com/monkukui/ac-library-go/blob/master/segtree/segtree.go
-// https://atcoder.github.io/ac-library/master/document_ja/segtree.html
-type SegmentTree[T any] struct {
-	n         int            // 初期化時に渡したスライスの要素数
-	data      []T            // セグメントツリーの本体
-	operation func(a, b T) T // モノイド積(?)を計算する関数
-	unit      T              // 単位元
+type SegmentTree[T any] interface {
+	Len() int
+	Set(i int, val T)
+	Get(i int) T
+	Product(l, r int) T
+	ProductAll() T
 }
 
-func NewSegmentTree[T any](s []T, op func(a, b T) T, unit T) *SegmentTree[T] {
-	sg := &SegmentTree[T]{
+func NewSegmentTree[T any](s []T, op func(a, b T) T, unit T) SegmentTree[T] {
+	sg := &segmentTree[T]{
 		n:         len(s),
 		data:      make([]T, len(s)*2),
 		operation: op,
@@ -31,11 +27,23 @@ func NewSegmentTree[T any](s []T, op func(a, b T) T, unit T) *SegmentTree[T] {
 	return sg
 }
 
-func (sg *SegmentTree[T]) Len() int {
+// 参考にさせていただいた記事:
+// https://maspypy.com/segment-tree-%e3%81%ae%e3%81%8a%e5%8b%89%e5%bc%b71
+// https://github.com/ktateish/go-competitive/blob/master/ac_segtree.go2
+// https://github.com/monkukui/ac-library-go/blob/master/segtree/segtree.go
+// https://atcoder.github.io/ac-library/master/document_ja/segtree.html
+type segmentTree[T any] struct {
+	n         int            // 初期化時に渡したスライスの要素数
+	data      []T            // セグメントツリーの本体
+	operation func(a, b T) T // モノイド積(?)を計算する関数
+	unit      T              // 単位元
+}
+
+func (sg *segmentTree[T]) Len() int {
 	return sg.n
 }
 
-func (sg *SegmentTree[T]) Set(idx int, v T) {
+func (sg *segmentTree[T]) Set(idx int, v T) {
 	now := sg.n + idx
 	sg.data[now] = v
 	for now > 1 {
@@ -44,11 +52,11 @@ func (sg *SegmentTree[T]) Set(idx int, v T) {
 	}
 }
 
-func (sg *SegmentTree[T]) Get(idx int) T {
+func (sg *segmentTree[T]) Get(idx int) T {
 	return sg.data[sg.n+idx]
 }
 
-func (sg *SegmentTree[T]) Product(l, r int) T {
+func (sg *segmentTree[T]) Product(l, r int) T {
 	l += sg.n
 	r += sg.n
 	valL, valR := sg.unit, sg.unit
@@ -67,11 +75,11 @@ func (sg *SegmentTree[T]) Product(l, r int) T {
 	return sg.operation(valL, valR)
 }
 
-func (sg *SegmentTree[T]) ProductAll() T {
+func (sg *segmentTree[T]) ProductAll() T {
 	return sg.Product(0, sg.n)
 }
 
-func (sg *SegmentTree[T]) update(now int) {
+func (sg *segmentTree[T]) update(now int) {
 	child1, child2 := now*2, now*2+1
 	sg.data[now] = sg.operation(sg.data[child1], sg.data[child2])
 }

--- a/data-structure/segtree/segtree.go
+++ b/data-structure/segtree/segtree.go
@@ -8,18 +8,34 @@ type SegmentTree[T any] interface {
 	ProductAll() T
 }
 
-func NewSegmentTree[T any](s []T, op func(a, b T) T, unit T) SegmentTree[T] {
+func NewSegmentTree[T any](n int, e func() T, op func(a, b T) T) SegmentTree[T] {
+	data := make([]T, n*2)
+	for i := range data {
+		data[i] = e()
+	}
 	sg := &segmentTree[T]{
-		n:         len(s),
-		data:      make([]T, len(s)*2),
-		operation: op,
-		unit:      unit,
+		n:    n,
+		data: data,
+		e:    e,
+		op:   op,
 	}
-	for i := 0; i < sg.n; i++ {
-		sg.data[i] = sg.unit
+	for i := sg.n - 1; i >= 1; i-- {
+		sg.update(i)
 	}
-	for i, v := range s {
-		sg.data[i+sg.n] = v
+	return sg
+}
+
+func NewSegmentTreeWith[T any](s []T, e func() T, op func(a, b T) T) SegmentTree[T] {
+	data := make([]T, len(s)*2)
+	for i := 0; i < len(s); i++ {
+		data[i] = e()
+	}
+	copy(data[len(s):], s)
+	sg := &segmentTree[T]{
+		n:    len(s),
+		data: data,
+		e:    e,
+		op:   op,
 	}
 	for i := sg.n - 1; i >= 1; i-- {
 		sg.update(i)
@@ -33,46 +49,46 @@ func NewSegmentTree[T any](s []T, op func(a, b T) T, unit T) SegmentTree[T] {
 // https://github.com/monkukui/ac-library-go/blob/master/segtree/segtree.go
 // https://atcoder.github.io/ac-library/master/document_ja/segtree.html
 type segmentTree[T any] struct {
-	n         int            // 初期化時に渡したスライスの要素数
-	data      []T            // セグメントツリーの本体
-	operation func(a, b T) T // モノイド積(?)を計算する関数
-	unit      T              // 単位元
+	n    int            // 初期化時に渡したスライスの要素数
+	data []T            // セグメントツリーの本体
+	e    func() T       // 単位元
+	op   func(a, b T) T // モノイド積(?)を計算する関数
 }
 
 func (sg *segmentTree[T]) Len() int {
 	return sg.n
 }
 
-func (sg *segmentTree[T]) Set(idx int, v T) {
-	now := sg.n + idx
-	sg.data[now] = v
+func (sg *segmentTree[T]) Set(i int, val T) {
+	now := sg.n + i
+	sg.data[now] = val
 	for now > 1 {
 		now /= 2
 		sg.update(now)
 	}
 }
 
-func (sg *segmentTree[T]) Get(idx int) T {
-	return sg.data[sg.n+idx]
+func (sg *segmentTree[T]) Get(i int) T {
+	return sg.data[sg.n+i]
 }
 
 func (sg *segmentTree[T]) Product(l, r int) T {
 	l += sg.n
 	r += sg.n
-	valL, valR := sg.unit, sg.unit
+	valL, valR := sg.e(), sg.e()
 	for l < r {
 		if l%2 == 1 {
-			valL = sg.operation(valL, sg.data[l])
+			valL = sg.op(valL, sg.data[l])
 			l++
 		}
 		if r%2 == 1 {
 			r--
-			valR = sg.operation(sg.data[r], valR)
+			valR = sg.op(sg.data[r], valR)
 		}
 		l /= 2
 		r /= 2
 	}
-	return sg.operation(valL, valR)
+	return sg.op(valL, valR)
 }
 
 func (sg *segmentTree[T]) ProductAll() T {
@@ -81,5 +97,5 @@ func (sg *segmentTree[T]) ProductAll() T {
 
 func (sg *segmentTree[T]) update(now int) {
 	child1, child2 := now*2, now*2+1
-	sg.data[now] = sg.operation(sg.data[child1], sg.data[child2])
+	sg.data[now] = sg.op(sg.data[child1], sg.data[child2])
 }

--- a/data-structure/segtree/segtree.go
+++ b/data-structure/segtree/segtree.go
@@ -19,9 +19,6 @@ func NewSegmentTree[T any](n int, e func() T, op func(a, b T) T) SegmentTree[T] 
 		e:    e,
 		op:   op,
 	}
-	for i := sg.n - 1; i >= 1; i-- {
-		sg.update(i)
-	}
 	return sg
 }
 


### PR DESCRIPTION
# 目的
ライブラリをコピペして利用するような場合でも非公開メソッドにアクセスできなくすること
またこれによってエディタの補完の精度を上げること

# 背景
競プロでGoを使う時、エディタ補完で不要な候補を表示させないために自分で書いた構造体のメソッドやフィールドを非公開にしたいと思うことがあった。しかし、下記の事情によりそれはできないと思っていた。

- 提出するコードは一つのファイルにまとめる必要があるためパッケージを分割できない
  - 競プロのジャッジでは、オンライン上のリポジトリから自由にライブラリをimportすることは許可されていない
  - 自作ライブラリの利用時はコピペするのが基本
- あるパッケージ内で定義した構造体をそれと同じパッケージから利用する場合、メソッドやフィールドを非公開に設定することはできない
  - Go特有？

interfaceを利用することで単一ファイルでの非公開を実現できたため、採用することにした。

# パフォーマンス
そこまで変わらないっぽい

# デバッグしづらくなるんじゃね？
`NewXXX`関数の返り値を実装型(？)に変更するだけで非公開メソッド・フィールドにアクセスできるようになるので、デバッグ時はそうする